### PR TITLE
feat(config): Update Wayland and X11 settings, adjust keyboard sensitivity

### DIFF
--- a/.config/hypr/hyprland.conf
+++ b/.config/hypr/hyprland.conf
@@ -22,8 +22,8 @@
 ################
 
 # See https://wiki.hyprland.org/Configuring/Monitors/
-monitor=DP-2,2560x1440@180,0x0,1
-monitor=DP-3,1920x1080@165,0x-1080,1
+monitor=DP-3,2560x1440@180,0x0,1
+monitor=DP-1,1920x1080@165,0x-1080,1
 
 
 ###################
@@ -46,6 +46,7 @@ $screenshot = grimblast --freeze copy area
 # Autostart necessary processes (like notifications daemons, status bars, etc.)
 # Or execute your favorite apps at launch like this:
 
+exec-once = hyprctl dispatch workspace 1
 exec-once = [workspace 1 silent] $terminal
 exec-once = waybar & hyprpaper
 exec-once = /usr/lib/polkit-kda-authentication-agent-1
@@ -170,7 +171,7 @@ input {
 
     follow_mouse = 1
 
-    sensitivity = 0 # -1.0 - 1.0, 0 means no modification.
+    sensitivity = -0.7 # -1.0 - 1.0, 0 means no modification.
 
     touchpad {
         natural_scroll = false
@@ -265,3 +266,5 @@ bindm = $mainMod, mouse:273, resizewindow
 # windowrulev2 = float,class:^(kitty)$,title:^(kitty)$
 windowrulev2 = float,class:git-butler
 windowrulev2 = suppressevent maximize, class:.* # You'll probably like this.
+
+workspace=name:1, monitor:DP-3

--- a/.config/hypr/hyprpaper.conf
+++ b/.config/hypr/hyprpaper.conf
@@ -1,5 +1,5 @@
 preload = /data/Art/Others/GUWEIZ/1.jpg
 preload = /data/Art/Others/GUWEIZ/change-17D1.jpg
-wallpaper = DP-2,/data/Art/Others/GUWEIZ/1.jpg
-wallpaper = DP-3,/data/Art/Others/GUWEIZ/change-17D1.jpg
+wallpaper = DP-3,/data/Art/Others/GUWEIZ/1.jpg
+wallpaper = DP-1,/data/Art/Others/GUWEIZ/change-17D1.jpg
 ipc = off

--- a/.config/kdeglobals
+++ b/.config/kdeglobals
@@ -1,2 +1,13 @@
 [General]
 TerminalApplication=alacritty
+
+[KDE]
+ShowDeleteCommand=false
+SingleClick=false
+
+[KShortcutsDialog Settings]
+Dialog Size=600,480
+
+[PreviewSettings]
+EnableRemoteFolderThumbnail=false
+MaximumRemoteSize=0

--- a/.config/vesktop-flags.conf
+++ b/.config/vesktop-flags.conf
@@ -1,1 +1,1 @@
---enable-features=UseOzonePlatform --ozone-platform=wayland
+--enable-features=UseOzonePlatform --ozone-platform=x11

--- a/.gitconfig
+++ b/.gitconfig
@@ -25,7 +25,7 @@
 	program = /usr/bin/gpg
 [gitbutler]
 	utmostdiscretion = 1
-	aimodelprovider = openai
+	aiModelProvider = anthropic
 	aiopenaikeyoption = butlerAPI
 [rerere]
 	enabled = true

--- a/.zshrc
+++ b/.zshrc
@@ -29,6 +29,11 @@ alias l="ls -lah"
 alias reload="source ~/.zshrc"
 alias find="find"
 alias open="xdg-open"
+alias cd="z"
+
+function cursor {
+	(nohup /opt/cursor-bin/cursor-bin.AppImage $@ > /dev/null 2>&1 &)
+}
 
 alias drop-caches='sudo paccache -rk3; paru -Sc --aur --noconfirm'
 alias update-all='export TMPFILE="$(mktemp)"; \
@@ -44,3 +49,5 @@ export PATH="$HOME/.cargo/bin:$PATH"
 source <(fnm env --use-on-cd --version-file-strategy=recursive)
 source <(fzf --zsh)
 source <(fnm completions --shell zsh)
+
+eval "$(zoxide init zsh)"


### PR DESCRIPTION
- Updates the Wayland and X11 settings in the `.config/vesktop-flags.conf` file
- Changes the monitor configurations in the `.config/hypr/hyprland.conf` file
- Adds the `zoxide` navigation tool and adjusts some shell aliases in the `.zshrc` file
- Configures KDE settings in the `.config/kdeglobals` file
- Starts the first workspace on Wayland startup in the `.config/hypr/hyprland.conf` file
- Updates the wallpaper configuration in the `.config/hypr/hyprpaper.conf` file
- Switches the AI model provider in the `.gitconfig` file
- Adjusts the mouse sensitivity in the `.config/hypr/hyprland.conf` file